### PR TITLE
feat(articles): add api favorite/unfavorite-article and optimize code

### DIFF
--- a/src/features/article/controller/article.controller.ts
+++ b/src/features/article/controller/article.controller.ts
@@ -72,4 +72,24 @@ export class ArticleController {
     }
     return this.articleService.delete(slug, currentUserId);
   }
+
+  @Post(':slug/favorite')
+  @UseGuards(JwtAuthGuard)
+  async favorite(@Param('slug') slug: string, @Request() req: any) {
+    const currentUserId = req.user?.id;
+    if (!currentUserId) {
+      throw new UnauthorizedException('User authentication required');
+    }
+    return this.articleService.favorite(slug, currentUserId);
+  }
+
+  @Delete(':slug/favorite')
+  @UseGuards(JwtAuthGuard)
+  async unfavorite(@Param('slug') slug: string, @Request() req: any) {
+    const currentUserId = req.user?.id;
+    if (!currentUserId) {
+      throw new UnauthorizedException('User authentication required');
+    }
+    return this.articleService.unfavorite(slug, currentUserId);
+  }
 }

--- a/src/features/article/service/article.service.ts
+++ b/src/features/article/service/article.service.ts
@@ -53,6 +53,13 @@ export interface FormattedArticle {
     following: boolean;
   };
 }
+export interface ArticleResponse {
+  article: FormattedArticle;
+}
+
+export interface DeleteArticleResponse {
+  message: string;
+}
 
 @Injectable()
 export class ArticleService {
@@ -190,7 +197,10 @@ export class ArticleService {
     }
   }
 
-  async create(createArticleDto: CreateArticleDto, currentUserId: number) {
+  async create(
+    createArticleDto: CreateArticleDto,
+    currentUserId: number,
+  ): Promise<ArticleResponse> {
     const { title, description, body, tagList } = createArticleDto;
 
     const slug = slugify(title, { lower: true, strict: true });
@@ -254,7 +264,7 @@ export class ArticleService {
     slug: string,
     updateArticleDto: UpdateArticleDto,
     currentUserId: number,
-  ) {
+  ): Promise<ArticleResponse> {
     const { title, description, body } = updateArticleDto;
 
     if (!title && !description && !body) {
@@ -319,7 +329,10 @@ export class ArticleService {
     };
   }
 
-  async delete(slug: string, currentUserId: number) {
+  async delete(
+    slug: string,
+    currentUserId: number,
+  ): Promise<DeleteArticleResponse> {
     const article = await this.findArticleBySlug(slug);
     this.checkArticleOwnership(article, currentUserId);
 
@@ -332,7 +345,10 @@ export class ArticleService {
     };
   }
 
-  async findOne(slug: string, currentUserId?: number) {
+  async findOne(
+    slug: string,
+    currentUserId?: number,
+  ): Promise<ArticleResponse> {
     const article = await this.findArticleBySlug(slug, currentUserId);
     const formattedArticle = await this.formatArticleResponse(
       article,
@@ -452,7 +468,10 @@ export class ArticleService {
     };
   }
 
-  async favorite(slug: string, currentUserId: number) {
+  async favorite(
+    slug: string,
+    currentUserId: number,
+  ): Promise<ArticleResponse> {
     const article = await this.findArticleBySlug(slug);
 
     const existingFavorite = await this.prisma.favorite.findUnique({
@@ -489,7 +508,10 @@ export class ArticleService {
     };
   }
 
-  async unfavorite(slug: string, currentUserId: number) {
+  async unfavorite(
+    slug: string,
+    currentUserId: number,
+  ): Promise<ArticleResponse> {
     const article = await this.findArticleBySlug(slug);
 
     const existingFavorite = await this.prisma.favorite.findUnique({

--- a/src/features/article/service/article.service.ts
+++ b/src/features/article/service/article.service.ts
@@ -485,11 +485,7 @@ export class ArticleService {
     );
 
     return {
-      article: {
-        ...formattedArticle,
-        favorited: true,
-        favoritesCount: article._count.favorites + 1,
-      },
+      article: formattedArticle,
     };
   }
 
@@ -523,11 +519,7 @@ export class ArticleService {
     );
 
     return {
-      article: {
-        ...formattedArticle,
-        favorited: false,
-        favoritesCount: article._count.favorites - 1,
-      },
+      article: formattedArticle,
     };
   }
 }


### PR DESCRIPTION
## Tổng quan
Refactor ArticleService and add Favorite/Unfavorite Articles function

## Các thay đổi
- Thêm 2 function favorite/unfavorite Articles function
- Thêm 2 interfaces `ArticleWithDetails` và `FormattedArticle` 
- Tạo function `findArticleBySlug()` 
- Implement `formatArticleResponse()` 
- Thêm `checkArticleOwnership()` 
- Refactor 5 methods (update, delete, findOne, favorite, unfavorite) giảm ~60-80% code duplication

## Impact
- Giảm duplicate code trong ArticleService
- Centralized logic giúp easier maintenance và debugging